### PR TITLE
readme: Remove outdated vulnerability information

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ cURL is included in Windows 10+, macOS, Android and many Linux distributions.
 
 The location of the scripts directory on Windows is `%APPDATA%\mpv\scripts` e.g. `C:\Users\cvzi\AppData\Roaming\mpv\scripts`
 
-$\textcolor{#D00000}{\textsf{Microsoft ships an old version of cURL with known vulnerabilities.}}$
 You are encouraged to install a newer version of cURL:
 * Official cURL releases https://curl.se/windows/
 * [Chocolatey package](https://community.chocolatey.org/packages/curl)
+* [Scoop package](https://github.com/ScoopInstaller/Main/blob/master/bucket/curl.json)
+* [Winget package](https://github.com/microsoft/winget-pkgs/tree/master/manifests/c/cURL/cURL)
 * [git for windows](https://git-scm.com/) includes a version of cURL
 
 If you downloaded/installed the curl/wget executable, you have to [add the directory of the curl.exe/wget.exe to your machine's


### PR DESCRIPTION
curl on Windows was updated very shortly after the severe vulnerability in 8.3.0, this information's almost a year out of date, and would only apply to out of support Windows versions (<= 8.1).
```
❯ where curl
C:\ProgramData\scoop\shims\curl.exe
c:\Windows\System32\curl.exe

❯ C:\ProgramData\scoop\shims\curl.exe --version
curl 8.10.1 (x86_64-w64-mingw32) libcurl/8.10.1 LibreSSL/3.9.2 zlib/1.3.1 brotli/1.1.0 zstd/1.5.6 WinIDN libpsl/0.21.5 libssh2/1.11.0 nghttp2/1.63.0 ngtcp2/1.7.0 nghttp3/1.5.0
Release-Date: 2024-09-18
Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns ldap ldaps mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp ws wss
Features: alt-svc AsynchDNS brotli CAcert HSTS HTTP2 HTTP3 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM PSL SPNEGO SSL SSPI threadsafe UnixSockets zstd

❯ c:\Windows\System32\curl.exe --version
curl 8.7.1 (Windows) libcurl/8.7.1 Schannel zlib/1.3 WinIDN
Release-Date: 2024-03-27
Protocols: dict file ftp ftps http https imap imaps ipfs ipns mqtt pop3 pop3s smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS HSTS HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM SPNEGO SSL SSPI threadsafe Unicode UnixSockets
```